### PR TITLE
Fix podspec to account for Objective C file renames

### DIFF
--- a/Quick.podspec
+++ b/Quick.podspec
@@ -16,13 +16,13 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.source       = { :git => "https://github.com/Quick/Quick.git", :tag => "v#{s.version}" }
-  s.source_files = "Sources/Quick/**/*.{swift,h,m}"
+  s.source_files = "Sources/**/*.{swift,h,m}"
 
   s.public_header_files = [
-    'Sources/Quick/Configuration/QuickConfiguration.h',
-    'Sources/Quick/DSL/QCKDSL.h',
-    'Sources/Quick/Quick.h',
-    'Sources/Quick/QuickSpec.h',
+    'Sources/QuickObjectiveC/Configuration/QuickConfiguration.h',
+    'Sources/QuickObjectiveC/DSL/QCKDSL.h',
+    'Sources/QuickObjectiveC/Quick.h',
+    'Sources/QuickObjectiveC/QuickSpec.h',
   ]
 
   s.exclude_files = [


### PR DESCRIPTION
Hi @norio-nomura. Objective C files were missing when installing your Swift 3 branch through CocoaPods (due to files being moved). This is a small change to update the podspec to use the new locations.